### PR TITLE
Major speed improvement: less HTTP requests

### DIFF
--- a/lib/Test/Pod/No404s.pm
+++ b/lib/Test/Pod/No404s.pm
@@ -14,6 +14,9 @@ my $Test = Test::Builder->new;
 
 # User agent
 our $UA;
+# Number of connections in cache
+# See LWP::ConnCache->total_capacity
+our $UA_KEEP_ALIVE = 8;
 
 # auto-export our 2 subs
 use parent qw( Exporter );
@@ -90,7 +93,10 @@ sub pod_file_ok {
 			# Verify the links!
 			my $ok = 1;
 			my @errors;
-			$UA ||= LWP::UserAgent->new();
+			$UA ||= LWP::UserAgent->new(
+				    env_proxy => 1,
+				    keep_alive => $UA_KEEP_ALIVE,
+			);
 			foreach my $l ( @links ) {
 				$Test->diag( "Checking $l->[0]" );
 				my $response = $UA->head( $l->[0] );

--- a/lib/Test/Pod/No404s.pm
+++ b/lib/Test/Pod/No404s.pm
@@ -97,7 +97,8 @@ sub pod_file_ok {
 				    env_proxy => 1,
 				    keep_alive => $UA_KEEP_ALIVE,
 			);
-			foreach my $l ( @links ) {
+			# Sort links to benefit from connection caching
+			foreach my $l ( sort { $a->[0] cmp $b->[0] } @links ) {
 				$Test->diag( "Checking $l->[0]" );
 				my $response = $UA->head( $l->[0] );
 				if ( $response->is_error ) {

--- a/lib/Test/Pod/No404s.pm
+++ b/lib/Test/Pod/No404s.pm
@@ -12,6 +12,9 @@ use Test::Pod ();
 use Test::Builder;
 my $Test = Test::Builder->new;
 
+# User agent
+our $UA;
+
 # auto-export our 2 subs
 use parent qw( Exporter );
 our @EXPORT = qw( pod_file_ok all_pod_files_ok ); ## no critic ( ProhibitAutomaticExportation )
@@ -87,10 +90,10 @@ sub pod_file_ok {
 			# Verify the links!
 			my $ok = 1;
 			my @errors;
-			my $ua = LWP::UserAgent->new;
+			$UA ||= LWP::UserAgent->new();
 			foreach my $l ( @links ) {
 				$Test->diag( "Checking $l->[0]" );
-				my $response = $ua->head( $l->[0] );
+				my $response = $UA->head( $l->[0] );
 				if ( $response->is_error ) {
 					$ok = 0;
 					push( @errors, [ $l->[1], $response->status_line ] );

--- a/lib/Test/Pod/No404s.pm
+++ b/lib/Test/Pod/No404s.pm
@@ -99,8 +99,16 @@ sub pod_file_ok {
 				    env_proxy => 1,
 				    keep_alive => $UA_KEEP_ALIVE,
 			);
+			@links = do {
+				# Keep unique links
+				my %links = map { $_->[0] => $_ } @links;
+				# Sort to benefit from connection caching
+				# (link to the same host with the same protocol
+				# will be checked in the same sequence)
+				map { $links{$_} } sort { $a cmp $b } keys %links
+			};
 			# Sort links to benefit from connection caching
-			foreach my $l ( sort { $a->[0] cmp $b->[0] } @links ) {
+			foreach my $l ( @links ) {
 				my $url = $l->[0];
 				if (exists $CACHE{$url}) {
 					$Test->diag( "Already checked $url" );


### PR DESCRIPTION
Major speed improvements:
- enable connection caching in LWP
- sort links to better use of this connection caching: connections to the same host will be tested in sequence
- check each URL only once (use a cache for responses accross files)
- remove duplicated links from a file before checking them

On my project [dolmen/github-keygen](https://github.com/dolmen/github-keygen/blob/b61c3cf0f2b44252b922f62084ea84c4164672fa/xt/03-no-404s.t) I have a 2.27x improvement: 18s instead of 41s.
