### PR TITLE
feat: URL ignore list

### DIFF
--- a/lib/Test/Pod/No404s.pm
+++ b/lib/Test/Pod/No404s.pm
@@ -11,6 +11,7 @@ use Test::Pod ();
 # setup our tests and etc
 use Test::Builder;
 my $Test = Test::Builder->new;
+my %ignore_urls;
 
 # auto-export our 2 subs
 use parent qw( Exporter );
@@ -68,6 +69,8 @@ sub pod_file_ok {
 		return 0;
 	}
 
+	_load_ignore_urls();
+
 	# Did we see POD in the file?
 	if ( $parser->doc_has_started ) {
 		my @links;
@@ -109,6 +112,30 @@ sub pod_file_ok {
 	}
 
 	return 1;
+}
+
+sub _load_ignore_urls {
+	return if ( %ignore_urls );
+
+	# Put a dummy item in %ignore_urls to not try to keep loading it over and over.
+	my $dummy = q{#};
+	$ignore_urls{ $dummy } = 1;
+
+	my $config = '.no404s-ignore';
+	$Test->diag( "Trying to load ignore URLs from $config" );
+	if ( -f $config ) {
+		open(my $F, '<', $config) or do {
+			$Test->diag( "Error reading $config: $!" );
+			return;
+		};
+		foreach my $line ( <$F> ) {
+			$line =~ s/^\s+//xms;
+			$line =~ s/\s+$//xms;
+			$ignore_urls{ $line } = 1;
+		}
+		close $F;
+	}
+	return;
 }
 
 =method all_pod_files_ok

--- a/lib/Test/Pod/No404s.pm
+++ b/lib/Test/Pod/No404s.pm
@@ -11,6 +11,7 @@ use Test::Pod ();
 # setup our tests and etc
 use Test::Builder;
 my $Test = Test::Builder->new;
+my %ignore_urls;
 
 # auto-export our 2 subs
 use parent qw( Exporter );
@@ -68,6 +69,8 @@ sub pod_file_ok {
 		return 0;
 	}
 
+	_load_ignore_urls();
+
 	# Did we see POD in the file?
 	if ( $parser->doc_has_started ) {
 		my @links;
@@ -89,6 +92,11 @@ sub pod_file_ok {
 			my @errors;
 			my $ua = LWP::UserAgent->new;
 			foreach my $l ( @links ) {
+				if ( $ignore_urls{$l->[0]} ) {
+					$Test->diag( "Ignoring $l->[0]" );
+					next;
+				}
+
 				$Test->diag( "Checking $l->[0]" );
 				my $response = $ua->head( $l->[0] );
 				if ( $response->is_error ) {
@@ -109,6 +117,30 @@ sub pod_file_ok {
 	}
 
 	return 1;
+}
+
+sub _load_ignore_urls {
+	return if ( %ignore_urls );
+
+	# Put a dummy item in %ignore_urls to not try to keep loading it over and over.
+	my $dummy = q{#};
+	$ignore_urls{ $dummy } = 1;
+
+	my $config = '.no404s-ignore';
+	$Test->diag( "Trying to load ignore URLs from $config" );
+	if ( -f $config ) {
+		open(my $F, '<', $config) or do {
+			$Test->diag( "Error reading $config: $!" );
+			return;
+		};
+		foreach my $line ( <$F> ) {
+			$line =~ s/^\s+//xms;
+			$line =~ s/\s+$//xms;
+			$ignore_urls{ $line } = 1;
+		}
+		close $F;
+	}
+	return;
 }
 
 =method all_pod_files_ok


### PR DESCRIPTION
This allows people to exclude URLs from checking. Some URLs may only be available in certain (company) networks, or may be rate limited, or may behave just plain weirdly.

In my case, my POD pointed to https://developer.twitter.com/apps/. When you go to that URL in a browser, you get redirected to a login page and fromthere to your Twitter developer settings. In curl and `LWP::UserAgent` you get a HTTP 405 ("method not allowed" seems odd here, I'd expect 3xx "redirect" or a 401 "not authorized"). This 405 is treated as an error cause it's not a 200 "ok", which makes sense from Test::Pod::No404s' point of view, and hence the test fails. Said Twitter URL is also rate-limited and hitting it too often gets you (temporarily) blocked.

With this patch I can add the bad URL to my .no404s-ignore file and have Test::Pod::No404s ignore that URL. This makes my tests pass and Twitter won't block me if I run my tests ten times in a row, just because I can.

There may be better ways for finding that ignore file (e.g., look in multiple locations), or the module could be extended to allow passing configuration arguments somehow. I wanted to keep the interface the same and the changes simple, hence this approach.

This patch does not include version number changes. I'd normally bump it to 0.3 as it's compatible with old code, but now new code cannot check the  rsion number to know whether the ignore files is supported. But I don't know how this module is versioned and distributed.